### PR TITLE
Fix proguard config

### DIFF
--- a/mopub-sample/proguard.cfg
+++ b/mopub-sample/proguard.cfg
@@ -10,8 +10,8 @@
 # Explicitly keep any custom event classes in any package.
 -keep class * extends com.mopub.mobileads.CustomEventBanner {}
 -keep class * extends com.mopub.mobileads.CustomEventInterstitial {}
+-keep class * extends com.mopub.mobileads.CustomEventRewardedAd {}
 -keep class * extends com.mopub.nativeads.CustomEventNative {}
--keep class * extends com.mopub.nativeads.CustomEventRewardedAd {}
 
 # Keep methods that are accessed via reflection
 -keepclassmembers class ** { @com.mopub.common.util.ReflectionTarget *; }

--- a/mopub-sdk/proguard.txt
+++ b/mopub-sdk/proguard.txt
@@ -10,8 +10,8 @@
 # Explicitly keep any custom event classes in any package.
 -keep class * extends com.mopub.mobileads.CustomEventBanner {}
 -keep class * extends com.mopub.mobileads.CustomEventInterstitial {}
+-keep class * extends com.mopub.mobileads.CustomEventRewardedAd {}
 -keep class * extends com.mopub.nativeads.CustomEventNative {}
--keep class * extends com.mopub.nativeads.CustomEventRewardedAd {}
 
 # Keep methods that are accessed via reflection
 -keepclassmembers class ** { @com.mopub.common.util.ReflectionTarget *; }


### PR DESCRIPTION
Proguard configuration refers to the wrong package
com.mopub.nativeads.CustomEventRewardedAd but should refer
to com.mopub.mobileads.CustomEventRewardedAd

This shows an alert in proguard logs